### PR TITLE
Fix service names should not be quoted

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -133,6 +133,6 @@ describe 'tacacsplus' do
       }
     end
 
-    it { should contain_file('/etc/tac_plus.conf').with_content(/^group = group_name {\n        default service = deny\n        login = PAM\n        pap = PAM\n        acl = acl_name\n        service = \"exec\" {\n            priv-lvl = \"15\"\n        }\n}$/) }
+    it { should contain_file('/etc/tac_plus.conf').with_content(/^group = group_name {\n        default service = deny\n        login = PAM\n        pap = PAM\n        acl = acl_name\n        service = exec {\n            priv-lvl = \"15\"\n        }\n}$/) }
   end
 end

--- a/templates/tac_plus.conf.erb
+++ b/templates/tac_plus.conf.erb
@@ -103,7 +103,7 @@ group = <%= group %> {
     <%- end -%>
     <%- if values.has_key?('service') -%>
     <%- values['service'].each_pair do |service, avp_array| -%>
-        service = "<%= service -%>" {
+        service = <%= service -%> {
         <%- avp_array.each do |avp| -%>
             <%- avp.each_pair do |attribute, value| -%>
             <%= attribute -%> = "<%= value %>"


### PR DESCRIPTION
Quoted service names will be silently ignored and never applied by the tacacsplus daemon. This commit ensures that the service names are not quoted by the template.
